### PR TITLE
Be more precise in specifying go-bindata

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -64,7 +64,7 @@
 [[projects]]
   branch = "master"
   name = "github.com/jteeuwen/go-bindata"
-  packages = ["."]
+  packages = [".","go-bindata"]
   revision = "a0ff2567cfb70903282db057e799fd826784d41d"
 
 [[projects]]
@@ -202,6 +202,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "58a56e505c2c650a1a62e4a6df5038948f1970d3ae15c90dc6e4f6ed25803d64"
+  inputs-digest = "3663c510930df1b446efa4d5fa324269ceea06afb3ded58887d49dd2a7b1c190"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -20,7 +20,7 @@
 #  name = "github.com/x/y"
 #  version = "2.4.0"
 
-required = ["github.com/jteeuwen/go-bindata"]
+required = ["github.com/jteeuwen/go-bindata/go-bindata"]
 
 [[constraint]]
   branch = "master"


### PR DESCRIPTION
I was exploring what it would cost to add the vendor directory to our
repository. After a vanilla dep ensure:

    ⌘ du -sh vendor
    48M    vendor

After running prune:

    ⌘ du -sh vendor
    19M    vendor

Before fixing this bug dep ensure would remove the unused
github.com/jteeuwen/go-bindata/go-bindata package, which would cause
subsequent builds to fail as:

    ⌘ dep prune
    ⌘ make
    go install ./vendor/github.com/jteeuwen/go-bindata/go-bindata
    can't load package: package github.com/ContextLogic/eventmaster/vendor/github.com/jteeuwen/go-bindata/go-bindata: cannot find package "github.com/ContextLogic/eventmaster/vendor/github.com/jteeuwen/go-bindata/go-bindata" in any of:
	    /usr/local/Cellar/go/1.9/libexec/src/github.com/ContextLogic/eventmaster/vendor/github.com/jteeuwen/go-bindata/go-bindata (from $GOROOT)
	    /Users/smcquay/src/github.com/ContextLogic/eventmaster/vendor/github.com/jteeuwen/go-bindata/go-bindata (from $GOPATH)
    make: *** [/Users/smcquay/bin/go-bindata] Error 1

This change fixes that and allows us to prune the directory and still get
consistent builds.